### PR TITLE
feat: add support for sign object only

### DIFF
--- a/nodejs-sign/sign.js
+++ b/nodejs-sign/sign.js
@@ -30,7 +30,8 @@ app.get('/ros', async (req, res) => {
   const encryptedRequestObject = await encryptJwt(signedRequestObject, await client.encryptionKey())
   const { data, error } = await client.ros(encryptedRequestObject)
   const uuid = data?.upload_uri?.split('/').pop()
-  res.render('ros.html', { requestObject, encryptedRequestObject, data, error, uuid })
+  const authUri = client.authUri(`${data?.request_uri}`)
+  res.render('ros.html', { requestObject, encryptedRequestObject, data, error, uuid, authUri })
 })
 
 // Uploads file to be signed

--- a/nodejs-sign/views/callback.html
+++ b/nodejs-sign/views/callback.html
@@ -28,7 +28,11 @@
     <pre><%= JSON.stringify(verifiedIdToken, null, 2) %></pre>
 
     <h2>Signed document</h2>
-    <a href="<%= verifiedIdToken?.structured_scope.documentObject.document_uri %>">Download</a>
+    <% if (verifiedIdToken?.structured_scope.documentObject) { %>
+      <a href="<%= verifiedIdToken?.structured_scope.documentObject.document_uri %>">Download</a>
+    <% } else { %>
+      There was no uploaded document.
+    <% } %>
 
     <p><a href="/ros">Start over</a></p>
   </body>

--- a/nodejs-sign/views/ros.html
+++ b/nodejs-sign/views/ros.html
@@ -9,12 +9,18 @@
   <body>
     <nav>
       <a href="/ros" class="active">Request object signature</a>&rsaquo;
-      <% if (data) { %>
+      <% if (data?.upload_uri) { %>
         <a href="/upload/<%= data.request_uri %>/<%= uuid %>">Upload file</a>&rsaquo;
       <% } else { %>
-        <a>Upload file</a>&rsaquo;
+        <a><s>Upload file</s> (no file)</a>&rsaquo;
       <% } %>
-      <a>Authorize</a>&rsaquo;
+
+      <% if (!data?.upload_uri) { %>
+        <a href="<%= authUri %>">Authorize</a>&rsaquo;
+      <% } else { %>
+        <a>Authorize</a>&rsaquo;
+      <% } %>
+
       <a>Callback</a>
     </nav>
 
@@ -28,7 +34,11 @@
     <pre><%= JSON.stringify(data ?? error, null, 2) %></pre>
 
     <% if (data) { %>
-      Continue to <a href="/upload/<%= data.request_uri %>/<%= uuid %>">upload file</a>
+      <% if (data?.upload_uri) { %>
+        Continue to <a href="/upload/<%= data.request_uri %>/<%= uuid %>">upload file</a>
+      <% } else { %>
+        Continue to <a href="<%= authUri %>">Authorize</a>
+      <% } %>
     <% } else { %>
       <a href="/ros">Start over</a>
     <% } %>


### PR DESCRIPTION
The previous implementation didn't support sign objects only because of the upload file step. I added the possibility to skip the upload step and go directly to authorize if no document is provided.